### PR TITLE
ci: use matrix.target as per-entry rust-cache key

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -189,7 +189,7 @@ jobs:
       - name: Setup Cache
         uses: Swatinem/rust-cache@v2
         with:
-          key: ${{ matrix.run_on }}
+          key: ${{ matrix.target }}
 
       - name: cargo build
         run: ${{ matrix.builder }} build --release --target ${{ matrix.target }} --features ci_build


### PR DESCRIPTION
## Summary

The `build` job in `.github/workflows/release.yml` is matrixed across five targets but keyed `Swatinem/rust-cache` on `${{ matrix.run_on }}`. That value is **not** unique per matrix entry:

- both macOS targets (`x86_64-apple-darwin`, `aarch64-apple-darwin`) share `macos-latest`
- both Linux targets (`x86_64-unknown-linux-musl`, `aarch64-unknown-linux-gnu`) share `ubuntu-latest`

So those entries clobbered each other's cache, defeating the purpose of caching per-target build artifacts.

## Change

Key the cache on `${{ matrix.target }}` instead, which is unique per matrix entry.

The single-entry `check` and `test` jobs already get a unique cache key from their job name, so they are left unchanged.

https://claude.ai/code/session_01BdHQMSXqwPqaZCYB9zM8fg

---
_Generated by [Claude Code](https://claude.ai/code/session_01BdHQMSXqwPqaZCYB9zM8fg)_