### PR TITLE
ci: Publish the container image from every main build

### DIFF
--- a/.deploy/deployment.yml
+++ b/.deploy/deployment.yml
@@ -24,7 +24,7 @@ spec:
     spec:
       containers:
         - name: server
-          image: sierrasoftworks/rex:latest
+          image: ghcr.io/sierrasoftworks/rex-rs:latest
           imagePullPolicy: IfNotPresent
           resources:
             requests:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,10 +33,20 @@ jobs:
         if: github.event_name == 'release'
         run: Add-Content -Path $env:GITHUB_ENV -Value "VERSION=$('${{ github.event.release.tag_name }}'.substring(1))"
 
+      # `:latest` is rebuilt from every push to main, so those builds need to be
+      # able to say which commit they are -- telemetry from a fleet of images all
+      # calling themselves 0.0.0-dev is not much use.
+      - name: Generate Package Version (Main Build)
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        run: echo "VERSION=0.0.0-dev.${{ github.run_number }}+${GITHUB_SHA::7}" >> $GITHUB_ENV
+
+      # Scoped to the package tables: `ui/Cargo.toml` declares web-sys with a
+      # `[dependencies.web-sys]` section whose `version =` sits at the start of
+      # a line too, and rewriting that pins web-sys to a version nobody has.
       - name: Set Package Version
         run: |
-          sed -i "s/^version\s*=\s*\".*\"/version = \"$VERSION\"/" Cargo.toml
-          sed -i "s/^version\s*=\s*\".*\"/version = \"$VERSION\"/" ui/Cargo.toml
+          sed -i "/^\[workspace\.package\]/,/^\[/ s/^version[[:space:]]*=[[:space:]]*\".*\"/version = \"$VERSION\"/" Cargo.toml
+          sed -i "/^\[package\]/,/^\[/ s/^version[[:space:]]*=[[:space:]]*\".*\"/version = \"$VERSION\"/" ui/Cargo.toml
 
       - name: Stash Versioned Manifests
         uses: actions/upload-artifact@v7
@@ -301,10 +311,15 @@ jobs:
   docker-build:
     name: Docker Build
     runs-on: ubuntu-latest
+    # Nothing reaches the registry unless the checks that gate it have passed:
+    # `:latest` now tracks main, so a red build must not be publishable.
     needs:
       - build
+      - check
+      - test
+      - e2e
 
-    if: github.event_name == 'release'
+    if: github.event_name == 'release' || (github.event_name == 'push' && github.ref == 'refs/heads/main')
 
     permissions:
       contents: read
@@ -346,6 +361,8 @@ jobs:
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=semver,pattern={{major}}
+            type=sha,format=long
+            type=raw,value=latest,enable={{is_default_branch}}
 
       - uses: actions/checkout@v7
 
@@ -386,7 +403,7 @@ jobs:
     needs:
       - docker-build
 
-    if: github.event_name == 'release'
+    if: github.event_name == 'release' || (github.event_name == 'push' && github.ref == 'refs/heads/main')
 
     permissions:
       contents: read
@@ -415,6 +432,13 @@ jobs:
         uses: docker/metadata-action@v6
         with:
           images: ${{ env.FULL_IMAGE_NAME }}
+          tags: |
+            type=ref,event=branch
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+            type=sha,format=long
+            type=raw,value=latest,enable={{is_default_branch}}
 
       - name: Log into registry ${{ env.REGISTRY }}
         uses: docker/login-action@v4.6.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,9 +9,10 @@ on:
   release:
     types: [ published ]
 
+# Declaring any permission sets every unlisted scope to `none`, so this is the
+# floor every job starts from. Jobs that need to write something ask for it.
 permissions:
-  id-token: write
-  packages: write
+  contents: read
 
 env:
   CARGO_TERM_COLOR: always
@@ -214,6 +215,10 @@ jobs:
   build:
     name: ${{ matrix.os }}-${{ matrix.arch }}-release
     runs-on: ${{ matrix.run_on }}
+
+    # Attaching binaries to the release writes to the repository.
+    permissions:
+      contents: write
 
     needs:
       - version

--- a/README.md
+++ b/README.md
@@ -16,8 +16,11 @@ Run the Docker image (published for `linux/amd64` and `linux/arm64`):
 docker run -p 8000:8000 \
   -v $(pwd)/config.toml:/config/config.toml:ro \
   -v rex-data:/data \
-  ghcr.io/sierrasoftworks/rex-rs/rex-rs:latest
+  ghcr.io/sierrasoftworks/rex-rs:latest
 ```
+
+The `latest` tag tracks `main`. Pin to a release (`:1`, `:1.2`, `:1.2.3`) or to a commit
+(`:sha-<commit>`) to choose when you move.
 
 Pre-compiled binaries for Linux, macOS, and Windows are available from the
 [GitHub releases](https://github.com/SierraSoftworks/rex-rs/releases) page.


### PR DESCRIPTION
`:latest` was only ever cut at release time. It now tracks `main`, so a merge is a
deployable image.

## What changed

- **`docker-build` and `docker-publish` run on pushes to `main`** as well as releases.
  Pull requests still publish nothing — a fork's token cannot write packages, and an
  unmerged branch has no business publishing.
- **Both jobs share one tag set.** `type=raw,value=latest,enable={{is_default_branch}}`
  gives `main` the `latest` tag; releases keep their semver tags; every build also gets an
  immutable `sha-<commit>` tag. `docker-publish` previously used the action's default
  tags, which is what actually decides the manifest list's tags.
- **The publish is gated on `check`, `test`, and `e2e`.** `docker-build` only needed
  `build` before. Now that a merge ships, a red build must not be publishable.
- **Main builds stamp `0.0.0-dev.<run>+<sha>`.** Every `:latest` image calling itself
  `0.0.0-dev` makes telemetry useless for working out what is running.

## Where the image lives

CI publishes to `ghcr.io/sierrasoftworks/rex-rs`, from `IMAGE_NAME: ${{ github.repository }}`.
The package that exists today is the nested `ghcr.io/sierrasoftworks/rex-rs/rex-rs` that
#830 documented, which nothing in this workflow writes to. The README and the k8s
Deployment both move to the path CI actually publishes; the nested package stops receiving
updates.

The Deployment was pointing at `sierrasoftworks/rex:latest` on Docker Hub, which CI has
never published to at all.

## Version rewrite fix

The `Set Package Version` step substituted any line starting with `version =`. In
`ui/Cargo.toml` that includes the `[dependencies.web-sys]` section, so a release build
would have rewritten `web-sys = "0.3"` to the package version and pinned it to something
that does not exist. It is now scoped to the `[workspace.package]` and `[package]` tables.

This never fired because the workflow has not run yet, and the `build` job does not read
`ui/Cargo.toml` — it downloads the prebuilt UI bundle.