### PR TITLE
build(ci): Build linux-arm64 on GitHub's native arm64 runners

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,2 +1,5 @@
 [target.x86_64-unknown-linux-musl]
 linker = "rust-lld"
+
+[target.aarch64-unknown-linux-musl]
+linker = "rust-lld"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -232,31 +232,28 @@ jobs:
             run_on: windows-latest
             target: x86_64-pc-windows-msvc
             extension: .exe
-            builder: cargo
 
           - arch: amd64
             run_on: ubuntu-latest
             os: linux
             target: x86_64-unknown-linux-musl
-            builder: cargo
             setup: |
               sudo apt update && sudo apt install -y musl-tools
           - arch: arm64
             os: linux
-            run_on: ubuntu-latest
+            run_on: ubuntu-24.04-arm
             target: aarch64-unknown-linux-musl
-            builder: cross
+            setup: |
+              sudo apt update && sudo apt install -y musl-tools
 
           - arch: amd64
             run_on: macos-latest
             os: darwin
             target: x86_64-apple-darwin
-            builder: cargo
           - arch: arm64
             run_on: macos-latest
             os: darwin
             target: aarch64-apple-darwin
-            builder: cargo
 
     steps:
       - name: Run setup script
@@ -269,13 +266,6 @@ jobs:
         with:
           toolchain: stable
           target: ${{ matrix.target }}
-
-      - name: Install Cross
-        if: matrix.builder == 'cross'
-        shell: bash
-        run: |
-          curl -L --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.sh | bash
-          cargo binstall --no-confirm cross
 
       - name: Fetch Versioned Manifests
         uses: actions/download-artifact@v8
@@ -297,7 +287,7 @@ jobs:
           key: ${{ matrix.target }}
 
       - name: cargo build
-        run: ${{ matrix.builder }} build --release --target ${{ matrix.target }} -p rex-server --features ci_build
+        run: cargo build --release --target ${{ matrix.target }} -p rex-server --features ci_build
 
       - name: Upload GitHub Release Artifacts
         uses: SierraSoftworks/gh-releases@v1.0.10


### PR DESCRIPTION
Switches the `linux-arm64` build from `cross` to GitHub's [native arm64 runners](https://docs.github.com/en/actions/reference/runners/github-hosted-runners) (`ubuntu-24.04-arm`, free for public repositories).

## What changed

- `build` matrix: the arm64 Linux entry now runs on `ubuntu-24.04-arm` and builds `aarch64-unknown-linux-musl` natively, with the same `musl-tools` setup script the amd64 musl entry already uses.
- Removed the cargo-binstall/`cross` install step and the `${{ matrix.builder }}` build indirection.
- With every entry now building with `cargo`, the `builder` matrix key is gone.
- `.cargo/config.toml` gains an `aarch64-unknown-linux-musl` entry pinning `rust-lld`, mirroring the override that target's x86_64 counterpart already carries.

`musl-tools` provides the `musl-gcc` that the `cc` crate needs to compile aws-lc-sys for a musl target.

## Why

The arm64 build was the only reason the workflow installed `cross` at all — a per-run binstall to get a container-based toolchain for one target. On a native arm64 runner it builds with the same steps as the amd64 musl entry.

## Verification

CI on this PR builds `linux-arm64` on the native runner. `docker-build` still gates on `build`, `check`, `test` and `e2e`, and consumes the same artifact names as before.


---
_Generated by [Claude Code](https://claude.ai/code/session_01VMWNbMN9txD8wr3uT9W1TJ)_